### PR TITLE
Fixed rake webhook:set[token] task

### DIFF
--- a/lib/webhook.rb
+++ b/lib/webhook.rb
@@ -43,7 +43,7 @@ module Webhook
       certificate = nil
     else
       puts "certificate file: #{certificate_file}".yellow
-      certificate = File.open(File.expand_path(certificate_file))
+      certificate = Faraday::UploadIO.new(File.expand_path(certificate_file), 'application/x-pem-file')
     end  
     resp = client.api.set_webhook(url: url_webhook, certificate: certificate)
 


### PR DESCRIPTION
This is fixing "rake webhook:set[token]" command.

It seems that certificate, opened with File.open is sent to Telegram server in wrong format. As a result, user receives "Webhook was set" response, but bot does not receive messages. Using Faraday::UploadIO class fixes the issue.